### PR TITLE
googletrans no longer works, updated readme, deepl support, code cleanup, caching

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+/output/
+/.idea/inspectionProfiles/
+/.idea/auto_localize.iml
+/.idea/

--- a/LanguageCodes.txt
+++ b/LanguageCodes.txt
@@ -1,6 +1,5 @@
 # Country Coding mapping
 # Name  |  Google Country Code (translate API)  | iOS Country Code (.lproj directory name)
-English en en
 French	fr fr
 German	de de
 ChineseSimplified	zh-CN zh-Hans

--- a/LanguageCodes.txt
+++ b/LanguageCodes.txt
@@ -1,10 +1,10 @@
 # Country Coding mapping
-# Name  |  Google Country Code (translate API)  | iOS Country Code (.lproj directory name)
-French	fr fr
-German	de de
-ChineseSimplified	zh-CN zh-Hans
-ChineseTraditional	zh-TW zh-Hant
-Japanese	ja ja
-Spanish	es es
-Italian	it it
-Korean ko ko
+# Name  |  Google Country Code (translate API)  | DeepL Country Code | iOS Country Code (.lproj directory name)
+French	fr fr fr
+German	de de de
+ChineseSimplified	zh-CN zh zh-Hans
+ChineseTraditional	zh-TW zh zh-Hant
+Japanese	ja ja ja
+Spanish	es es es
+Italian	it it it
+Korean ko - ko

--- a/Localizable.strings
+++ b/Localizable.strings
@@ -8,3 +8,4 @@
 
 "Hello" = "Hello";
 "World" = "World";
+"The calendar '%@' does not support meetings." = "The calendar '%@' does not support meetings.";

--- a/Localizable.strings
+++ b/Localizable.strings
@@ -8,4 +8,3 @@
 
 "Hello" = "Hello";
 "World" = "World";
-"The calendar '%@' does not support meetings." = "The calendar '%@' does not support meetings.";

--- a/README.md
+++ b/README.md
@@ -1,15 +1,21 @@
 # auto_localize
-Auto translate Localizable.strings for multiple languages in Xcode
+Auto translate Localizable.strings for multiple languages in Xcode using Google Translate or DeepL
 
 # Usage
 1. put your origin `Localizable.strings` file in folder
 2. `pip3 install googletrans==4.0.0-rc1`
-3. `python3 strings.py`
+3. `pip3 install --upgrade deepl`
+4. `python3 strings.py`
 
 ![image](https://user-images.githubusercontent.com/2985638/133636085-7e3b7c1b-efcc-430a-a478-383ddd9e634f.png)
 
 # how to specify custom path to Localizable.strings
 `python3 strings.py -f /some/path/to/Localizable.strings`
+
+# how to use DeepL
+Google Translate is used by default. To switch to DeepL you must also specify an authentication token, like so:
+
+`python3 strings.py -t deepl -a AUTH_TOKEN_HERE`
 
 # how to set origin languge
 you can use `-o` to set your origin language,
@@ -20,6 +26,13 @@ the default origin is english
 
 # how to add more language
 update `LanguageCodes.txt` to add or remove support languages
+
+# how to translate only non-translated lines
+To translate only the lines that have not been translated already, you need to specify a path to a root directory with existing translations (that contain directories such as `fr.lproj` etc):
+
+`python3 strings.py -d PATH_TO_EXISTING_TRANSLATIONS`
+
+This will then ignore translating any line that already exists. 
 
 # how to enable verbose printing
 `python3 strings.py -v`

--- a/README.md
+++ b/README.md
@@ -2,12 +2,14 @@
 Auto translate Localizable.strings for multiple languages in Xcode
 
 # Usage
-1. put your origin Localizable.strings file in folder
-2. pip3 install googletrans
-3. python3 strings.py
+1. put your origin `Localizable.strings` file in folder
+2. `pip3 install googletrans==4.0.0-rc1`
+3. `python3 strings.py`
 
 ![image](https://user-images.githubusercontent.com/2985638/133636085-7e3b7c1b-efcc-430a-a478-383ddd9e634f.png)
 
+# how to specify custom path to Localizable.strings
+`python3 strings.py -f /some/path/to/Localizable.strings`
 
 # how to set origin languge
 you can use `-o` to set your origin language,
@@ -17,5 +19,8 @@ for example `python3 strings.py -o fr`,
 the default origin is english
 
 # how to add more language
-update LanguageCodes.txt to add or remove support languages
+update `LanguageCodes.txt` to add or remove support languages
+
+# how to enable verbose printing
+`python3 strings.py -v`
 

--- a/strings.py
+++ b/strings.py
@@ -1,5 +1,4 @@
 import re
-import requests
 import os
 import argparse
 from googletrans import Translator
@@ -7,12 +6,42 @@ from googletrans import Translator
 translator = Translator()
 
 parser = argparse.ArgumentParser()
+parser.add_argument("-f", default="Localizable.strings", help="set the path to the original Localizable.strings to read keys from")
 parser.add_argument("-o", default="en", help="set the origin locale for auto translation, default is english")
+parser.add_argument("-v", default="1", help="Verbose")
 args = parser.parse_args()
+
+# Read and cache origin language once
+originLines = []
+with open(args.f, 'r') as stringsFile:
+    for line in stringsFile:
+        # Ignore empty lines
+        if len(line.strip()) == 0:
+            continue
+        # endif
+
+        # Ignore lines we cannot translate
+        matchSource = re.search(r'\"(.*)\"(.*)\"(.*)\"', line)
+        if matchSource:
+            stringName = matchSource.group(1)
+            sourceText = matchSource.group(3)
+
+            translationCouple = (stringName, sourceText)
+
+            originLines.append(translationCouple)
+        else:
+            if args.v == '1':
+                print("   ignoring source line: %s" % (line))
+            #end if
+        #end if
+    # end for
+# end with
 
 def createDirectoryIfNotExists(fileName):
     if not os.path.exists(os.path.dirname(fileName)):
         os.makedirs(os.path.dirname(fileName))
+    #end if
+#end def
 
 def writeToFile(sourceText, translatedText, target):
     fileName = "output/" + target + ".lproj/Localizable.strings"
@@ -20,36 +49,41 @@ def writeToFile(sourceText, translatedText, target):
         createDirectoryIfNotExists(fileName)
         contentToWrite = "\"" + sourceText + "\" = \"" + translatedText + "\";\n"
         myfile.write(contentToWrite)
+    #end with
+#end def
 
 def translateSourceText(sourceText, target):
     try:
         obj = translator.translate(sourceText, src=args.o, dest=target)
-    except:
+    except Exception as e:
+        print("   translation failed for: %s = %s" % (sourceText, e))
         return sourceText   
     return obj.text
+#end def
 
-def translateLineInFile(line, target, outputTarget):
-    matchSource = re.search(r'\"(.*)\"(.*)\"(.*)\"', line)
-    if matchSource:
-        stringName = matchSource.group(1)
-        sourceText = matchSource.group(3)
-        translation = translateSourceText(sourceText, target)
-        writeToFile(stringName, translation, outputTarget)
+def translateLineInFile(translationCouple, target, outputTarget):
+    stringName = translationCouple[0]
+    sourceText = translationCouple[1]
+
+    translation = translateSourceText(sourceText, target)
+    writeToFile(stringName, translation, outputTarget)
+#end def
 
 def clearContentsOfFile(target):
     fileName = "output/" + target + ".lproj/Localizable.strings"
     createDirectoryIfNotExists(fileName)
     open(fileName, 'w').close()
+#end def
 
 def translateFile(translateName, target, outputTarget):
-
     print("Translating for: " + translateName)
 
     clearContentsOfFile(outputTarget)
 
-    with open('Localizable.strings', 'r') as stringsFile:
-        for line in stringsFile:
-            translateLineInFile(line, translateTarget, outputTarget)
+    for translationCouple in originLines:
+        translateLineInFile(translationCouple, translateTarget, outputTarget)
+    #end for
+#end def
 
 
 with open('LanguageCodes.txt', 'r') as targetsFile:
@@ -63,5 +97,7 @@ with open('LanguageCodes.txt', 'r') as targetsFile:
         outputTarget = targetArray[2]
 
         translateFile(translateName, translateTarget, outputTarget)
+    #end for
+#end def
 
 

--- a/strings.py
+++ b/strings.py
@@ -192,7 +192,10 @@ def translateLineInFile(translationTuple, translateTargetCode, outputTargetCode)
 
     (translation, success) = translateSourceText(sourceText, translateTargetCode)
 
-    writeToFile(stringName, translation, outputTargetCode)
+    if success:
+        # Only save translated lines
+        writeToFile(stringName, translation, outputTargetCode)
+    #end if
 
     return success
 #end def

--- a/strings.py
+++ b/strings.py
@@ -68,12 +68,11 @@ def readTranslations(fileName):
         return []
     #endif
 
-    readLines = []
-
     stringset = []
     f = _get_content_from_file(filename=fileName)
     if f.startswith(u'\ufeff'):
         f = f.lstrip(u'\ufeff')
+    #end if
     # regex for finding all comments in a file
     cp = r'(?:/\*(?P<comment>(?:[^*]|(?:\*+[^*/]))*\**)\*/)'
     p = re.compile(
@@ -89,15 +88,19 @@ def readTranslations(fileName):
         end_ = i.end()
         key = i.group('key')
         comment = i.group('comment') or ''
+
         if not key:
             key = i.group('property')
+        #end if
+
         value = i.group('value')
         while end < start:
             m = c.match(f, end, start) or ws.match(f, end, start)
             if not m or m.start() != end:
-                print("Invalid syntax: %s" % \
-                      f[end:start])
+                print("Invalid syntax: %s" % f[end:start])
+            #end if
             end = m.end()
+        #end while
         end = end_
         key = _unescape_key(key)
         stringset.append({'key': key, 'value': _unescape(value), 'comment': comment})

--- a/strings.py
+++ b/strings.py
@@ -8,10 +8,13 @@ translator = Translator()
 parser = argparse.ArgumentParser()
 parser.add_argument("-f", default="Localizable.strings", help="set the path to the original Localizable.strings to read keys from")
 parser.add_argument("-o", default="en", help="set the origin locale for auto translation, default is english")
+parser.add_argument("-d", default="", help="For delta translations. Set the path to the root directory where existing localized translations exist. If specified, this path will be used to check if a line / key has already been translated and skip translating that line. This way only the keys that do not exist in the existing destination file will be translated.")
 parser.add_argument("-v", default="1", help="Verbose")
 args = parser.parse_args()
 
 # Read and cache origin language once
+print("Reading source language: %s" % (args.f))
+
 originLines = []
 with open(args.f, 'r') as stringsFile:
     for line in stringsFile:
@@ -26,9 +29,9 @@ with open(args.f, 'r') as stringsFile:
             stringName = matchSource.group(1)
             sourceText = matchSource.group(3)
 
-            translationCouple = (stringName, sourceText)
+            translationTuple = (stringName, sourceText)
 
-            originLines.append(translationCouple)
+            originLines.append(translationTuple)
         else:
             if args.v == '1':
                 print("   ignoring source line: %s" % (line))
@@ -37,66 +40,124 @@ with open(args.f, 'r') as stringsFile:
     # end for
 # end with
 
-def createDirectoryIfNotExists(fileName):
+print("Total lines in source: %s\n" % (len(originLines)))
+
+def createOutputDirectoryIfNotExists(fileName):
     if not os.path.exists(os.path.dirname(fileName)):
         os.makedirs(os.path.dirname(fileName))
     #end if
 #end def
 
-def writeToFile(sourceText, translatedText, target):
-    fileName = "output/" + target + ".lproj/Localizable.strings"
+def writeToFile(sourceText, translatedText, outputTargetCode):
+    fileName = "output/" + outputTargetCode + ".lproj/Localizable.strings"
     with open(fileName, "a") as myfile:
-        createDirectoryIfNotExists(fileName)
+        createOutputDirectoryIfNotExists(fileName)
         contentToWrite = "\"" + sourceText + "\" = \"" + translatedText + "\";\n"
         myfile.write(contentToWrite)
     #end with
 #end def
 
-def translateSourceText(sourceText, target):
+def translateSourceText(sourceText, translateTargetCode):
+    """
+    Return translation for source text
+    :param sourceText: source text to translate
+    :param translateTargetCode: target language (google translation code)
+    :return:
+    """
     try:
-        obj = translator.translate(sourceText, src=args.o, dest=target)
+        obj = translator.translate(sourceText, src=args.o, dest=translateTargetCode)
     except Exception as e:
-        print("   translation failed for: %s = %s" % (sourceText, e))
-        return sourceText   
-    return obj.text
+        if args.v == '1':
+            print("   FAILED to translate for %s: %s = %s" % (translateTargetCode, sourceText, e))
+        #endif
+        return (sourceText, False)
+    #end try
+
+    return (obj.text, True)
 #end def
 
-def translateLineInFile(translationCouple, target, outputTarget):
-    stringName = translationCouple[0]
-    sourceText = translationCouple[1]
+def translationNeeded(translationTuple, translateTargetCode, outputTargetCode):
+    """
+    Check if translation is required for a given source key. If not delta-translating, this will always return True
+    other wise False if translation key found in original target Localizable.strings file.
 
-    translation = translateSourceText(sourceText, target)
-    writeToFile(stringName, translation, outputTarget)
+    :param translationTuple: key / value
+    :param translateTargetCode:  target language
+    :param outputTargetCode:  traget output file
+    :return: True if needed, False if translation was found in the original target.
+    """
+    stringName = translationTuple[0]
+    sourceText = translationTuple[1]
+
+    return True
+#end def
+
+def translateLineInFile(translationTuple, translateTargetCode, outputTargetCode):
+    """
+    Translate a given key / value tuple to a target language.
+
+    :param translationTuple: key / value
+    :param translateTargetCode:  target language
+    :param outputTargetCode:  output target code
+    """
+    stringName = translationTuple[0]
+    sourceText = translationTuple[1]
+
+    (translation, success) = translateSourceText(sourceText, translateTargetCode)
+
+    writeToFile(stringName, translation, outputTargetCode)
+
+    return success
 #end def
 
 def clearContentsOfFile(target):
     fileName = "output/" + target + ".lproj/Localizable.strings"
-    createDirectoryIfNotExists(fileName)
+    createOutputDirectoryIfNotExists(fileName)
     open(fileName, 'w').close()
 #end def
 
-def translateFile(translateName, target, outputTarget):
-    print("Translating for: " + translateName)
+def translateFile(translateFriendlyName, translateTargetCode, outputTargetCode):
+    """
+    Translate source language for the given target language / output file
+    :param translateFriendlyName: friendly name for printing
+    :param translateTargetCode: google translation target code
+    :param outputTargetCode: output target code
+    :return:
+    """
+    print("Translating for: " + translateFriendlyName)
 
-    clearContentsOfFile(outputTarget)
+    clearContentsOfFile(outputTargetCode)
 
-    for translationCouple in originLines:
-        translateLineInFile(translationCouple, translateTarget, outputTarget)
+    totalLinesTranslated = 0
+    totalLinesNeeded = 0
+    for translationTuple in originLines:
+        if translationNeeded(translationTuple, translateTargetCode, outputTargetCode):
+            totalLinesNeeded += 1
+
+            if translateLineInFile(translationTuple, translateTargetCode, outputTargetCode):
+                totalLinesTranslated += 1
+            #end if
+        #end if
     #end for
+
+    if totalLinesNeeded != totalLinesTranslated:
+        print("    WARNING: Total lines translated: %s. Original source count: %s" % (totalLinesTranslated, totalLinesNeeded))
+    #end if
 #end def
 
+with open('LanguageCodes.txt', 'r') as supportedLangCodeFile:
+    for targetLine in supportedLangCodeFile:
 
-with open('LanguageCodes.txt', 'r') as targetsFile:
-    for targetLine in targetsFile:
-
-        if "#" in targetLine:
+        if targetLine.strip().startswith("#"):
             continue
-        targetArray = targetLine.split()
-        translateName = targetArray[0]
-        translateTarget = targetArray[1]
-        outputTarget = targetArray[2]
+        #end if
 
-        translateFile(translateName, translateTarget, outputTarget)
+        targetArray = targetLine.split()
+        translateFriendlyName = targetArray[0]
+        translateTargetCode = targetArray[1]
+        outputTargetCode = targetArray[2]
+
+        translateFile(translateFriendlyName, translateTargetCode, outputTargetCode)
     #end for
 #end def
 


### PR DESCRIPTION
- `googletrans` no longer works, updated Readme with a _fix_
- DeepL support (switch between Google Translate / DeepL)
- Since default source language is `en`, LanguageCodes.txt updated to remove en
- Read the source / origin language once and cache the key / value pairs
- Option added to ignore translating lines that already exist in an existing target translation
- Option added to support verbose printing
- Option added to specify a custom path to Localizable.strings
- Basic validations
- Cleanup